### PR TITLE
Trying to run a test against REST services

### DIFF
--- a/drools-game-engine-services/pom.xml
+++ b/drools-game-engine-services/pom.xml
@@ -12,6 +12,8 @@
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
+		<version.resteasy>3.0.14.Final</version.resteasy>
+    	<version.arquillian-bom>1.1.10.Final</version.arquillian-bom>    
     </properties>
     <dependencies>
         <dependency>
@@ -24,8 +26,47 @@
             <artifactId>jaxrs-cdi</artifactId>
             
         </dependency>
-        
+		<dependency>
+			<groupId>org.wildfly.swarm</groupId>
+			<artifactId>arquillian</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.jboss.arquillian.junit</groupId>
+			<artifactId>arquillian-junit-container</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+	    	<groupId>org.jboss.resteasy</groupId>
+	    	<artifactId>resteasy-client</artifactId>
+	    	<version>${version.resteasy}</version>
+	    	<scope>test</scope>
+	    </dependency>
+	    <dependency>
+	    	<groupId>org.jboss.resteasy</groupId>
+	    	<artifactId>resteasy-jackson2-provider</artifactId>
+	    	<version>${version.resteasy}</version>
+	    	<scope>test</scope>
+	    </dependency>
+	    <dependency>
+            <groupId>org.jboss.arquillian.container</groupId>
+            <artifactId>arquillian-weld-se-embedded-1.1</artifactId>
+            <version>1.0.0.CR9</version>
+            <scope>test</scope>
+        </dependency>        
     </dependencies>
+	<dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.jboss.arquillian</groupId>
+                <artifactId>arquillian-bom</artifactId>
+                <version>${version.arquillian-bom}</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+    
     <build>
         <plugins>
             <plugin>

--- a/drools-game-engine-services/src/test/java/com/drools/game/services/endpoint/test/GameServiceTest.java
+++ b/drools-game-engine-services/src/test/java/com/drools/game/services/endpoint/test/GameServiceTest.java
@@ -1,0 +1,60 @@
+package com.drools.game.services.endpoint.test;
+
+import java.util.List;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.GenericType;
+import javax.ws.rs.core.MediaType;
+
+import org.drools.game.services.infos.GameSessionInfo;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(Arquillian.class)
+public class GameServiceTest 
+{
+
+	private Client client;
+	
+	@Before
+	public void setup() throws Exception {
+		client = ClientBuilder.newClient();
+
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		client.close();
+	}
+
+    @Deployment
+    public static JavaArchive createDeployment() {
+
+        JavaArchive jar = ShrinkWrap.create( JavaArchive.class )
+                .addAsManifestResource( EmptyAsset.INSTANCE, "beans.xml" );
+//        System.out.println( jar.toString( true ) );
+        return jar;
+    }
+
+    
+
+	@Test
+	public void getAllGameSessions() {
+		WebTarget target = client.target("http://localhost:8080/api/game");
+
+		List<GameSessionInfo> sessions = target.request(MediaType.APPLICATION_JSON)
+				.get(new GenericType<List<GameSessionInfo>>() {
+				});
+		org.junit.Assert.assertEquals(0, sessions.size());
+	}
+
+}


### PR DESCRIPTION
Hi @Salaboy ,

My thought is to run tests against the service, and then implement the REST services.

I have followed this guide https://wildfly-swarm.gitbooks.io/wildfly-swarm-users-guide/content/testing_with_arquillian.html
and added some extra dependencies into the pom file, but at this point I get the following exception and I don't know how to solve it.

Any suggestion/indication?

`
Tests run: 1, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 0.725 sec <<< FAILURE!
com.drools.game.services.endpoint.test.GameServiceTest  Time elapsed: 0.725 sec  <<< ERROR!
java.lang.RuntimeException: Could not create new instance of class org.jboss.arquillian.test.impl.EventTestRunnerAdaptor
    at org.jboss.arquillian.test.spi.SecurityActions.newInstance(SecurityActions.java:165)
    at org.jboss.arquillian.test.spi.SecurityActions.newInstance(SecurityActions.java:102)
    at org.jboss.arquillian.test.spi.TestRunnerAdaptorBuilder.build(TestRunnerAdaptorBuilder.java:52)
    at org.jboss.arquillian.junit.Arquillian.run(Arquillian.java:113)
    at org.apache.maven.surefire.junit4.JUnit4Provider.execute(JUnit4Provider.java:252)
    at org.apache.maven.surefire.junit4.JUnit4Provider.executeTestSet(JUnit4Provider.java:141)
    at org.apache.maven.surefire.junit4.JUnit4Provider.invoke(JUnit4Provider.java:112)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:497)
    at org.apache.maven.surefire.util.ReflectionUtils.invokeMethodWithArray(ReflectionUtils.java:189)
    at org.apache.maven.surefire.booter.ProviderFactory$ProviderProxy.invoke(ProviderFactory.java:165)
    at org.apache.maven.surefire.booter.ProviderFactory.invokeProvider(ProviderFactory.java:85)
    at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:115)
    at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:75)
Caused by: java.lang.reflect.InvocationTargetException
    at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
    at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
    at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
    at java.lang.reflect.Constructor.newInstance(Constructor.java:422)
    at org.jboss.arquillian.test.spi.SecurityActions.newInstance(SecurityActions.java:161)
    ... 15 more
Caused by: org.jboss.arquillian.container.impl.ContainerCreationException: Could not create Container daemon
    at org.jboss.arquillian.container.impl.LocalContainerRegistry.create(LocalContainerRegistry.java:85)
    at org.jboss.arquillian.container.impl.client.container.ContainerRegistryCreator.createRegistry(ContainerRegistryCreator.java:78)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:497)
    at org.jboss.arquillian.core.impl.ObserverImpl.invoke(ObserverImpl.java:94)
    at org.jboss.arquillian.core.impl.EventContextImpl.invokeObservers(EventContextImpl.java:99)
    at org.jboss.arquillian.core.impl.EventContextImpl.proceed(EventContextImpl.java:81)
    at org.jboss.arquillian.core.impl.ManagerImpl.fire(ManagerImpl.java:145)
    at org.jboss.arquillian.core.impl.ManagerImpl.fire(ManagerImpl.java:116)
    at org.jboss.arquillian.core.impl.ManagerImpl.bindAndFire(ManagerImpl.java:265)
    at org.jboss.arquillian.core.impl.InstanceImpl.set(InstanceImpl.java:74)
    at org.jboss.arquillian.config.impl.extension.ConfigurationRegistrar.loadConfiguration(ConfigurationRegistrar.java:73)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:497)
    at org.jboss.arquillian.core.impl.ObserverImpl.invoke(ObserverImpl.java:94)
    at org.jboss.arquillian.core.impl.EventContextImpl.invokeObservers(EventContextImpl.java:99)
    at org.jboss.arquillian.core.impl.EventContextImpl.proceed(EventContextImpl.java:81)
    at org.jboss.arquillian.core.impl.ManagerImpl.fire(ManagerImpl.java:145)
    at org.jboss.arquillian.core.impl.ManagerImpl.fire(ManagerImpl.java:116)
    at org.jboss.arquillian.core.impl.ManagerImpl.start(ManagerImpl.java:290)
    at org.jboss.arquillian.test.impl.EventTestRunnerAdaptor.<init>(EventTestRunnerAdaptor.java:63)
    ... 20 more
Caused by: java.lang.IllegalStateException: Multiple service implementations found for interface org.jboss.arquillian.container.spi.client.container.DeployableContainer. org.jboss.arquillian.container.weld.se.embedded_1_1.WeldSEContainer, org.wildfly.swarm.arquillian.adapter.WildFlySwarmContainer
    at org.jboss.arquillian.core.impl.loadable.ServiceRegistryLoader.onlyOne(ServiceRegistryLoader.java:74)
    at org.jboss.arquillian.container.impl.LocalContainerRegistry.create(LocalContainerRegistry.java:80)
    ... 44 more`
